### PR TITLE
Editing a display's name and status bar icons

### DIFF
--- a/api/models/Display.js
+++ b/api/models/Display.js
@@ -1,12 +1,19 @@
 const mongoose = require('mongoose')
+const shortid = require('shortid')
+
 const Schema = mongoose.Schema
 
 const Display = new Schema({
   name: { type: String },
   layout: { type: String, default: 'spaced', enum: ['compact', 'spaced'] },
   statusBar: {
-    type: [{ type: String, enum: ['time', 'date', 'connection', 'spacer'] }],
-    default: ['date', 'spacer', 'connection', 'time']
+    type: [{ type: String }],
+    default: () => [
+      'date_' + shortid.generate(),
+      'spacer_' + shortid.generate(),
+      'connection_' + shortid.generate(),
+      'time_' + shortid.generate()
+    ]
   },
   widgets: [{ type: Schema.Types.ObjectId, ref: 'Widget' }]
 })

--- a/components/Admin/EditableWidget.js
+++ b/components/Admin/EditableWidget.js
@@ -58,7 +58,6 @@ class EditableWidget extends React.Component {
             <FontAwesomeIcon icon={widget.icon || faTimes} size={'2x'} />
           </div>
           <span className={'type'}>{widget.name || 'Broken Widget'}</span>
-          {/* <span className={'name'}>NEWS</span> */}
         </div>
         <WidgetEditDialog ref={this.dialog} OptionsComponent={widget.Options} id={id} />
         <style jsx>

--- a/components/Admin/ScreenCard.js
+++ b/components/Admin/ScreenCard.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faWindowRestore } from '@fortawesome/free-regular-svg-icons'
 import { faChromecast } from '@fortawesome/free-brands-svg-icons'
-import { faTrash, faTv } from '@fortawesome/free-solid-svg-icons'
+import { faTrash, faTv, faEye, faLink } from '@fortawesome/free-solid-svg-icons'
 import Link from 'next/link'
 import { view } from 'react-easy-state'
 
@@ -41,6 +41,16 @@ class ScreenCard extends Component {
             </div>
           </div>
           <div className='right'>
+            <Link href={'/layout?display=' + value._id}>
+              <div className='actionIcon'>
+                <FontAwesomeIcon icon={faEye} fixedWidth color='#828282' />
+              </div>
+            </Link>
+            <Link href={'/display/' + value._id}>
+              <div className='actionIcon'>
+                <FontAwesomeIcon icon={faLink} fixedWidth color='#828282' />
+              </div>
+            </Link>
             <div className='actionIcon'>
               <FontAwesomeIcon
                 icon={faTrash}
@@ -159,8 +169,8 @@ class ScreenCard extends Component {
               }
 
               .actionIcon {
-                margin-right: 8px;
-                margin-left: 8px;
+                margin-right: 16px;
+                margin-left: 16px;
               }
             `}
           </style>

--- a/components/Admin/StatusBarElement.js
+++ b/components/Admin/StatusBarElement.js
@@ -1,0 +1,127 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { library, config } from '@fortawesome/fontawesome-svg-core'
+import { faTimes } from '@fortawesome/free-solid-svg-icons'
+import { Draggable } from 'react-beautiful-dnd'
+
+import { StatusBarElementTypes } from '../../helpers/statusbar.js'
+
+config.autoAddCss = false
+library.add(faTimes)
+
+class StatusBarElement extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+
+  deleteClicked = e => {
+    if (e) e.stopPropagation()
+    const { onDelete = () => {} } = this.props
+    onDelete()
+  }
+
+  render() {
+    const { item, index } = this.props
+    const type = item.split('_')[0]
+    return (
+      <Draggable key={item} draggableId={item} index={index}>
+        {provided => (
+          <div
+            ref={provided.innerRef}
+            {...provided.draggableProps}
+            {...provided.dragHandleProps}
+            className={'statusBarEl'}
+            style={{
+              ...provided.draggableProps.style
+            }}
+          >
+            <div className={'controls'}>
+              <div className={'delete'} onClick={this.deleteClicked}>
+                <FontAwesomeIcon icon={faTimes} size={'xs'} fixedWidth />
+              </div>
+            </div>
+            <div className={'info'}>
+              <div className={'icon'}>
+                <FontAwesomeIcon icon={StatusBarElementTypes[type].icon || faTimes} size={'sm'} />
+              </div>
+              <span className={'type'}>{type || 'Unknown'}</span>
+            </div>
+            <style jsx>
+              {`
+                .statusBarEl {
+                  background-color: rgba(108, 108, 108, 1);
+                  border-radius: 6px;
+                  height: 100%;
+                  width: 100%;
+                  box-sizing: border-box;
+                  padding: 8px;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: center;
+                  cursor: move;
+                  overflow: hidden;
+                  position: relative;
+                }
+                .statusBarEl .info {
+                  display: flex;
+                  flex-direction: row;
+                  justify-content: center;
+                  align-items: center;
+                  color: white;
+                }
+                .statusBarEl .info .icon {
+                  color: white;
+                  margin-right: 16px;
+                }
+                .statusBarEl .info .type {
+                  color: white;
+                  font-family: 'Open Sans', sans-serif;
+                  text-transform: uppercase;
+                  font-size: 14px;
+                  white-space: nowrap;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  max-width: 100%;
+                }
+                .statusBarEl .controls {
+                  position: absolute;
+                  font-family: 'Open Sans', sans-serif;
+                  height: 100%;
+                  justify-content: flex-end;
+                  align-items: center;
+                  display: none;
+                  top: 0px;
+                  right: 0px;
+                }
+                .statusBarEl .delete {
+                  display: flex;
+                  font-family: 'Open Sans', sans-serif;
+                  width: 32px;
+                  height: 32px;
+                  justify-content: center;
+                  align-items: center;
+                  color: white;
+                  border-radius: 50%;
+                  cursor: pointer;
+                  margin-right: 8px;
+                }
+
+                .statusBarEl .delete {
+                  background: rgba(252, 50, 50, 0.6);
+                }
+
+                .statusBarEl:hover .controls {
+                  display: flex;
+                }
+              `}
+            </style>
+          </div>
+        )}
+      </Draggable>
+    )
+  }
+}
+
+export default StatusBarElement

--- a/components/Display/Frame.js
+++ b/components/Display/Frame.js
@@ -13,41 +13,28 @@ class Frame extends React.Component {
     super(props)
   }
 
-  renderStatusBarElement = type => {
-    return (
-      <div className={type}>
-        {type == 'date' ? (
-          <Clock ticking={true} format={'dddd, MMMM Do.'} />
-        ) : type == 'connection' ? (
-          <FontAwesomeIcon className={'wifi'} icon={faWifi} />
-        ) : type == 'time' ? (
-          <Clock ticking={true} format={'H:mm'} />
-        ) : (
-          ' '
-        )}
-      </div>
-    )
-  }
-
   render() {
     const { children, statusBar = [] } = this.props
     return (
       <div className='display'>
         {statusBar && statusBar.length > 0 && (
           <div className={'status'}>
-            {statusBar.map(type => (
-              <div className={type}>
-                {type == 'date' ? (
-                  <Clock ticking={true} format={'dddd, MMMM Do.'} />
-                ) : type == 'connection' ? (
-                  <FontAwesomeIcon className={'wifi'} icon={faWifi} />
-                ) : type == 'time' ? (
-                  <Clock ticking={true} format={'H:mm'} />
-                ) : (
-                  ' '
-                )}
-              </div>
-            ))}
+            {statusBar.map(item => {
+              const type = item.split('_')[0]
+              return (
+                <div className={type}>
+                  {type == 'date' ? (
+                    <Clock ticking={true} format={'dddd, MMMM Do.'} />
+                  ) : type == 'connection' ? (
+                    <FontAwesomeIcon className={'wifi'} icon={faWifi} />
+                  ) : type == 'time' ? (
+                    <Clock ticking={true} format={'H:mm'} />
+                  ) : (
+                    ' '
+                  )}
+                </div>
+              )
+            })}
           </div>
         )}
         {children}

--- a/helpers/statusbar.js
+++ b/helpers/statusbar.js
@@ -1,0 +1,27 @@
+import { library, config } from '@fortawesome/fontawesome-svg-core'
+import { faRss, faGripVertical, faClock, faCalendarAlt } from '@fortawesome/free-solid-svg-icons'
+
+config.autoAddCss = false
+library.add(faRss)
+library.add(faGripVertical)
+library.add(faClock)
+library.add(faCalendarAlt)
+
+export const StatusBarElementTypes = {
+  time: {
+    name: 'time',
+    icon: faClock
+  },
+  date: {
+    name: 'date',
+    icon: faCalendarAlt
+  },
+  spacer: {
+    name: 'spacer',
+    icon: faGripVertical
+  },
+  connection: {
+    name: 'connection',
+    icon: faRss
+  }
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "passport-local": "^1.0.0",
     "passport-local-mongoose": "^5.0.1",
     "react": "^16.8.6",
+    "react-beautiful-dnd": "^11.0.4",
     "react-color": "^2.17.0",
     "react-content-loader": "^4.2.1",
     "react-dom": "^16.8.2",
@@ -74,10 +75,12 @@
     "react-sortable-hoc": "^1.8.3",
     "react-switch": "^5.0.0",
     "react-youtube": "^7.9.0",
+    "shortid": "^2.2.14",
     "socket.io": "^2.2.0",
     "socket.io-client": "^2.2.0",
     "styled-components": "^4.2.0",
     "superagent": "^5.0.5",
+    "uuid": "^3.3.2",
     "webfontloader": "^1.6.28"
   },
   "devDependencies": {

--- a/pages/index.js
+++ b/pages/index.js
@@ -22,7 +22,7 @@ class Index extends React.Component {
   }
 
   navigateToDisplay = id => {
-    Router.push('/display?display=' + id)
+    Router.push('/display/' + id)
   }
 
   render() {

--- a/pages/layout.js
+++ b/pages/layout.js
@@ -3,13 +3,17 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faThLarge, faTh, faPencilAlt } from '@fortawesome/free-solid-svg-icons'
 import GridLayout from 'react-grid-layout'
 import { view } from 'react-easy-state'
+import { DragDropContext, Droppable } from 'react-beautiful-dnd'
 
 import Frame from '../components/Admin/Frame.js'
 import EditableWidget from '../components/Admin/EditableWidget'
+import StatusBarElement from '../components/Admin/StatusBarElement'
 import WidthProvider from '../components/Widgets/WidthProvider'
 import DropdownButton from '../components/DropdownButton'
 
 import { Form, Switch } from '../components/Form'
+
+import { StatusBarElementTypes } from '../helpers/statusbar.js'
 
 import Widgets from '../widgets'
 
@@ -67,6 +71,14 @@ class Layout extends React.Component {
     }
   }
 
+  onDragEnd = result => {
+    if (!result.destination) {
+      return
+    }
+
+    display.reorderStatusBarItems(result.source.index, result.destination.index)
+  }
+
   render() {
     const { widgets } = this.state
     const { loggedIn } = this.props
@@ -101,6 +113,51 @@ class Layout extends React.Component {
               <FontAwesomeIcon icon={faPencilAlt} fixedWidth color='#828282' />
             </div>
           </div>
+        </div>
+        <div className='settings'>
+          <DropdownButton
+            icon='plus'
+            text='Add Status Bar Item'
+            onSelect={display.addStatusBarItem}
+            choices={Object.keys(StatusBarElementTypes).map(statusBarEl => ({
+              key: statusBarEl,
+              name: StatusBarElementTypes[statusBarEl].name,
+              icon: StatusBarElementTypes[statusBarEl].icon
+            }))}
+          />
+        </div>
+        <div className='statusbar'>
+          {display && display.statusBar && (
+            <DragDropContext onDragEnd={this.onDragEnd}>
+              <Droppable droppableId='droppable' direction='horizontal'>
+                {provided => (
+                  <div
+                    ref={provided.innerRef}
+                    style={{
+                      display: 'flex',
+                      paddingTop: 8,
+                      paddingBottom: 8,
+                      paddingRight: 4,
+                      paddingLeft: 4,
+                      overflow: 'auto',
+                      height: '100%',
+                      boxSizing: 'border-box'
+                    }}
+                    {...provided.droppableProps}
+                  >
+                    {display.statusBar.map((item, index) => (
+                      <StatusBarElement
+                        item={item}
+                        index={index}
+                        onDelete={display.removeStatusBarItem.bind(this, index)}
+                      />
+                    ))}
+                    {provided.placeholder}
+                  </div>
+                )}
+              </Droppable>
+            </DragDropContext>
+          )}
         </div>
         <div className='settings'>
           <DropdownButton
@@ -163,6 +220,13 @@ class Layout extends React.Component {
             .layout {
               background: #dfdfdf;
               border-radius: ${display.layout == 'spaced' ? '8px' : '0px'};
+            }
+            .statusbar {
+              background: #dfdfdf;
+              border-radius: 8px;
+              flex: 1;
+              margin-bottom: 16px;
+              height: 64px;
             }
             .settings {
               display: flex;

--- a/pages/layout.js
+++ b/pages/layout.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { faThLarge, faTh } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faThLarge, faTh, faPencilAlt } from '@fortawesome/free-solid-svg-icons'
 import GridLayout from 'react-grid-layout'
 import { view } from 'react-easy-state'
 
@@ -81,6 +82,25 @@ class Layout extends React.Component {
       <Frame loggedIn={loggedIn}>
         <div className={'head'}>
           <h1>Layout</h1>
+          <div className='editable-title'>
+            <input
+              className='input'
+              placeholder='Unnamed display'
+              value={display && display.name}
+              onChange={event => {
+                const target = event.target
+                const title = target && target.value
+                display.updateName(title)
+              }}
+              onClick={e => {
+                if (e) e.stopPropagation()
+              }}
+              size={display && display.name && display.name.length}
+            />
+            <div className='icon'>
+              <FontAwesomeIcon icon={faPencilAlt} fixedWidth color='#828282' />
+            </div>
+          </div>
         </div>
         <div className='settings'>
           <DropdownButton
@@ -150,6 +170,30 @@ class Layout extends React.Component {
               align-items: center;
               justify-content: space-between;
               margin-bottom: 16px;
+            }
+            .editable-title {
+              display: inline-block;
+              position: relative;
+              margin-left: 16px;
+              margin-right: 16px;
+              border-bottom: 3px solid #aaa;
+            }
+            .editable-title .input {
+              font-family: 'Open Sans', sans-serif;
+              color: #666;
+              background-color: transparent;
+              min-height: 40px;
+              border: none;
+              outline: none;
+              margin-right: 24px;
+              font-size: 24px;
+              font-weight: 600;
+            }
+            .editable-title .icon {
+              position: absolute;
+              right: 8px;
+              top: 50%;
+              margin-top: -8px;
             }
           `}
         </style>

--- a/routes.js
+++ b/routes.js
@@ -1,3 +1,5 @@
 const routes = require('next-routes')
 
-module.exports = routes().add('/slideshow/:id', 'slideshow')
+module.exports = routes()
+  .add('/slideshow/:id', 'slideshow')
+  .add('/display/:display', 'display')

--- a/stores/display.js
+++ b/stores/display.js
@@ -2,6 +2,7 @@ const ReactEasyState = require('react-easy-state')
 const store = ReactEasyState.store
 const _ = require('lodash')
 const DisplayActions = require('../actions/display')
+const shortid = require('shortid')
 
 const updateDisplayThrottled = _.debounce((id, data) => {
   return DisplayActions.updateDisplay(id, data)
@@ -35,6 +36,23 @@ const display = store({
     if (!layout || !['spaced', 'compact'].includes(layout)) return
     display.layout = layout
     updateDisplayThrottled(display.id, { layout })
+  },
+  addStatusBarItem(type) {
+    display.statusBar = [...display.statusBar, type + '_' + shortid.generate()]
+    updateDisplayThrottled(display.id, { statusBar: display.statusBar })
+    return Promise.resolve()
+  },
+  removeStatusBarItem(id) {
+    display.statusBar = [...display.statusBar.slice(0, id).concat(display.statusBar.slice(id + 1))]
+    updateDisplayThrottled(display.id, { statusBar: display.statusBar })
+  },
+  reorderStatusBarItems(startIndex, endIndex) {
+    const result = Array.from(display.statusBar)
+    const [removed] = result.splice(startIndex, 1)
+    result.splice(endIndex, 0, removed)
+
+    display.statusBar = result
+    updateDisplayThrottled(display.id, { statusBar: display.statusBar })
   }
 })
 


### PR DESCRIPTION
Part of #1 

### Changes
- Adds ability to change a display's identifying name to distinguish different screens
- Adds ability to modify status bar icons or remove the status bar completely

### Screenshots
<img width="971" alt="Screen Shot 2019-06-15 at 7 18 33 PM" src="https://user-images.githubusercontent.com/591655/59557432-191b2d80-8fa8-11e9-9dbd-5a5db43e60c3.png">
 